### PR TITLE
Update Mark1.mq5

### DIFF
--- a/CIndicators/CCustomVolume
+++ b/CIndicators/CCustomVolume
@@ -1,0 +1,31 @@
+//+------------------------------------------------------------------+
+//|                                                        CustomVolume.mqh |
+//|                         Copyright 2024, Avanzamos Africa Pty LTD |
+//|                                         https://avanzamos.africa |
+//+------------------------------------------------------------------+
+#include <Expert\ExpertSignal.mqh>
+
+class CCustomVolume : public CExpertSignal
+  {
+public:
+   double VolumeValue;
+
+   //--- constructor
+   CCustomVolume(void)
+     {
+      VolumeValue = 0;
+     }
+
+   //--- signal initialization
+   virtual bool Init( void )
+     {
+      return(true);
+     }
+
+   //--- calculate signal
+   virtual double Calculate( void )
+     {
+      VolumeValue = iVolume(NULL, 0, 0);
+      return(VolumeValue);
+     }
+  };

--- a/CIndicators/CSignalBollingerBands
+++ b/CIndicators/CSignalBollingerBands
@@ -1,0 +1,48 @@
+//+------------------------------------------------------------------+
+//|                                         CustomBollingerBands.mqh |
+//|                         Copyright 2024, Avanzamos Africa Pty LTD |
+//|                                         https://avanzamos.africa |
+//+------------------------------------------------------------------+
+#include <Expert\ExpertSignal.mqh>
+
+class CSignalBollingerBands : public CExpertSignal
+  {
+public:
+   double BollingerBandsUpper, BollingerBandsLower, BollingerBandsMiddle;
+
+   //--- constructor
+   CSignalBollingerBands(void)
+     {
+      BollingerBandsUpper = 0;
+      BollingerBandsLower = 0;
+      BollingerBandsMiddle = 0;
+     }
+
+   //--- signal initialization
+   virtual bool Init( void )
+     {
+      // Example of initializing parameters if needed
+      return(true);
+     }
+
+   //--- calculate signal
+   virtual double Calculate( void )
+     {
+      int limit = 100;
+      double upper[], lower[], middle[];
+      ArrayResize(upper, limit);
+      ArrayResize(lower, limit);
+      ArrayResize(middle, limit);
+
+      // Calculate Bollinger Bands
+      CopyBuffer(iBands(NULL, PERIOD_CURRENT, 14, 2.0, 0, PRICE_CLOSE), 1, 0, limit, upper);
+      CopyBuffer(iBands(NULL, PERIOD_CURRENT, 14, 2.0, 0, PRICE_CLOSE), 2, 0, limit, lower);
+      CopyBuffer(iBands(NULL, PERIOD_CURRENT, 14, 2.0, 0, PRICE_CLOSE), 0, 0, limit, middle);
+
+      BollingerBandsUpper = upper[limit-1];
+      BollingerBandsLower = lower[limit-1];
+      BollingerBandsMiddle = middle[limit-1];
+
+      return(0.0);
+     }
+  };

--- a/Mark1.mq5
+++ b/Mark1.mq5
@@ -5,7 +5,7 @@
 //+------------------------------------------------------------------+
 #property copyright "Copyright 2024, Avanzamos Africa Pty LTD"
 #property link      "https://avanzamos.africa"
-#property version   "1.05"
+#property version   "1.07"
 //+------------------------------------------------------------------+
 //| Include                                                          |
 //+------------------------------------------------------------------+
@@ -15,10 +15,15 @@
 #include <Expert\Signal\SignalMA.mqh>
 #include <Expert\Signal\SignalMACD.mqh>
 #include <Expert\Signal\SignalCCI.mqh>
+//--- custom signals
+#include <Avanzamos\SignalBollingerBands.mqh>
 //--- available trailing
 #include <Expert\Trailing\TrailingMA.mqh>
+#include <Expert\Trailing\TrailingParabolicSAR.mqh>
 //--- available money management
 #include <Expert\Money\MoneyFixedRisk.mqh>
+//--- custom volume indicator
+#include <Avanzamos\CCustomVolume.mqh>
 //+------------------------------------------------------------------+
 //| Inputs                                                           |
 //+------------------------------------------------------------------+
@@ -31,7 +36,9 @@ input int                Signal_ThresholdOpen =20;          // Signal threshold 
 input int                Signal_ThresholdClose=20;          // Signal threshold value to close [0...100]
 input double             Signal_PriceLevel    =0.0;         // Price level to execute a deal
 input double             Signal_StopLevel     =100.0;       // Stop Loss level (in points)
-input double             Signal_TakeLevel     =150.0;       // Take Profit level (in points)
+input double             Signal_TakeLevel1    =50.0;        // Take Profit level 1 (in points)
+input double             Signal_TakeLevel2    =100.0;       // Take Profit level 2 (in points)
+input double             Signal_TakeLevel3    =150.0;       // Take Profit level 3 (in points)
 input int                Signal_Expiration    =4;           // Expiration of pending orders (in bars)
 input int                Signal_RSI_PeriodRSI =14;          // Relative Strength Index(14,...) Period of calculation
 input ENUM_APPLIED_PRICE Signal_RSI_Applied   =PRICE_CLOSE; // Relative Strength Index(14,...) Prices series
@@ -41,6 +48,8 @@ input int                Trailing_MA_Period   =50;          // Period of MA
 input int                Trailing_MA_Shift    =0;           // Shift of MA
 input ENUM_MA_METHOD     Trailing_MA_Method   =MODE_EMA;    // Method of averaging
 input ENUM_APPLIED_PRICE Trailing_MA_Applied  =PRICE_CLOSE; // Prices series
+input double             Trailing_PSAR_Step   =0.02;        // Parabolic SAR step
+input double             Trailing_PSAR_Max    =0.2;         // Parabolic SAR maximum
 //--- inputs for money
 input double             Money_FixRisk_Percent=0.5;         // Risk percentage
 input int                ATR_Period           =14;          // ATR period for dynamic position sizing
@@ -99,7 +108,7 @@ int OnInit()
    signal.ThresholdClose(Signal_ThresholdClose);
    signal.PriceLevel(Signal_PriceLevel);
    signal.StopLevel(Signal_StopLevel);
-   signal.TakeLevel(Signal_TakeLevel);
+   signal.TakeLevel(Signal_TakeLevel3);  // Use the highest take profit level for initialization
    signal.Expiration(Signal_Expiration);
 //--- Creating filter CSignalRSI
    CSignalRSI *filter0=new CSignalRSI;
@@ -147,28 +156,68 @@ int OnInit()
       return(INIT_FAILED);
      }
    signal.AddFilter(cciFilter);
-//--- Creation of trailing object
-   CTrailingMA *trailing=new CTrailingMA;
-   if(trailing==NULL)
+//--- Creating custom Bollinger Bands filter
+   CSignalBollingerBands *bbFilter=new CSignalBollingerBands;
+   if(bbFilter==NULL)
      {
       //--- failed
-      printf(__FUNCTION__+": error creating trailing");
+      printf(__FUNCTION__+": error creating custom Bollinger Bands filter");
       ExtExpert.Deinit();
       return(INIT_FAILED);
      }
-//--- Add trailing to expert (will be deleted automatically)
-   if(!ExtExpert.InitTrailing(trailing))
+   signal.AddFilter(bbFilter);
+//--- Creating custom volume indicator
+   CCustomVolume *volumeFilter=new CCustomVolume;
+   if(volumeFilter==NULL)
      {
       //--- failed
-      printf(__FUNCTION__+": error initializing trailing");
+      printf(__FUNCTION__+": error creating volume filter");
       ExtExpert.Deinit();
       return(INIT_FAILED);
      }
-//--- Set trailing parameters
-   trailing.Period(Trailing_MA_Period);
-   trailing.Shift(Trailing_MA_Shift);
-   trailing.Method(Trailing_MA_Method);
-   trailing.Applied(Trailing_MA_Applied);
+   signal.AddFilter(volumeFilter);
+//--- Creation of trailing MA object
+   CTrailingMA *trailingMA=new CTrailingMA;
+   if(trailingMA==NULL)
+     {
+      //--- failed
+      printf(__FUNCTION__+": error creating trailingMA");
+      ExtExpert.Deinit();
+      return(INIT_FAILED);
+     }
+//--- Add trailing MA to expert (will be deleted automatically)
+   if(!ExtExpert.InitTrailing(trailingMA))
+     {
+      //--- failed
+      printf(__FUNCTION__+": error initializing trailingMA");
+      ExtExpert.Deinit();
+      return(INIT_FAILED);
+     }
+//--- Set trailing MA parameters
+   trailingMA.Period(Trailing_MA_Period);
+   trailingMA.Shift(Trailing_MA_Shift);
+   trailingMA.Method(Trailing_MA_Method);
+   trailingMA.Applied(Trailing_MA_Applied);
+//--- Creation of Parabolic SAR trailing object
+   CTrailingPSAR *trailingPSAR=new CTrailingPSAR;
+   if(trailingPSAR==NULL)
+     {
+      //--- failed
+      printf(__FUNCTION__+": error creating trailingPSAR");
+      ExtExpert.Deinit();
+      return(INIT_FAILED);
+     }
+//--- Add trailing PSAR to expert (will be deleted automatically)
+   if(!ExtExpert.InitTrailing(trailingPSAR))
+     {
+      //--- failed
+      printf(__FUNCTION__+": error initializing trailingPSAR");
+      ExtExpert.Deinit();
+      return(INIT_FAILED);
+     }
+//--- Set trailing PSAR parameters
+   trailingPSAR.Step(Trailing_PSAR_Step);
+   trailingPSAR.Maximum(Trailing_PSAR_Max);
 //--- Creation of money object with dynamic position sizing
    CMoneyFixedRisk *money=new CMoneyFixedRisk;
    if(money==NULL)


### PR DESCRIPTION
Traded To may without hitting drawdown limit. Net loss 1500

Key Updates:

    Enhanced Time-Based Filtering:
        Adjusted trading hours to 06:00 to 20:00, avoiding early hours with high losses.

    Additional Confirmation Indicators:
        Added MACD and CCI filters to improve signal accuracy.

    Refined Risk Management:
        Reduced the risk per trade to 0.5%.
        Introduced dynamic position sizing based on ATR value.

    Optimized Exit Strategy:
        The exit strategy remains flexible for further refinement.